### PR TITLE
Use afterglow yellow and black colors for selected text to make selections more visible

### DIFF
--- a/Afterglow.itermcolors
+++ b/Afterglow.itermcolors
@@ -194,20 +194,20 @@
 	<key>Selected Text Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.81568628549575806</real>
+		<real>0.10588235408067703</real>
 		<key>Green Component</key>
-		<real>0.81568628549575806</real>
+		<real>0.10588235408067703</real>
 		<key>Red Component</key>
-		<real>0.81568628549575806</real>
+		<real>0.10588235408067703</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.18823529779911041</real>
+		<real>0.47450980544090271</real>
 		<key>Green Component</key>
-		<real>0.18823529779911041</real>
+		<real>0.75686275959014893</real>
 		<key>Red Component</key>
-		<real>0.18823529779911041</real>
+		<real>0.91764706373214722</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #2.

Before change:

![image](https://user-images.githubusercontent.com/15214/67496194-aa2e9f00-f641-11e9-96a3-2e20a57e38e8.png)

After change:

![image](https://user-images.githubusercontent.com/15214/67497190-41e0bd00-f643-11e9-934a-40c37dfdcf30.png)
